### PR TITLE
Replace empty "staking" tab with a link to the vote/governance page

### DIFF
--- a/src/components/TopBar/components/Nav.tsx
+++ b/src/components/TopBar/components/Nav.tsx
@@ -25,9 +25,12 @@ const Nav: React.FC = () => {
 			>
 				Menu
 			</StyledLink>
-			<StyledAbsoluteLink href="https://snapshot.page/#/baovotes.eth" target="_blank">
+			<StyledAbsoluteLink
+				href="https://snapshot.page/#/baovotes.eth"
+				target="_blank"
+			>
 				Vote
-			</StyledAbsoluteLink>			
+			</StyledAbsoluteLink>
 			<StyledAbsoluteLink href="https://docs.bao.finance" target="_blank">
 				About
 			</StyledAbsoluteLink>

--- a/src/components/TopBar/components/Nav.tsx
+++ b/src/components/TopBar/components/Nav.tsx
@@ -25,13 +25,9 @@ const Nav: React.FC = () => {
 			>
 				Menu
 			</StyledLink>
-			<StyledLink
-				exact
-				activeClassName="active"
-				to={{ pathname: '/staking', search: '?ref=' + refer }}
-			>
-				Staking
-			</StyledLink>
+			<StyledAbsoluteLink href="https://snapshot.page/#/baovotes.eth" target="_blank">
+				Vote
+			</StyledAbsoluteLink>			
 			<StyledAbsoluteLink href="https://docs.bao.finance" target="_blank">
 				About
 			</StyledAbsoluteLink>


### PR DESCRIPTION
People seem confused by the empty staking tab. So this PR simply replaces it with a link to the Vote/Governance page. The wording **Vote** was copied from the Uniswap navigation, so people should be familiar with it. 

<img width="905" alt="Screenshot of Google Chrome (04-01-21, 15-36-43)" src="https://user-images.githubusercontent.com/76935490/103516190-a97ad500-4ea2-11eb-88d2-e7edd2cd97e3.png">
