### PR TITLE
Update linter to use the correct default branch.

### DIFF
--- a/.github/workflows/lint_code_base.yml
+++ b/.github/workflows/lint_code_base.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Run Super-Linter
         uses: github/super-linter@v3
         env:
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           LINTER_RULES_PATH: /
           JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.js 
           VALIDATE_JAVASCRIPT_ES: true


### PR DESCRIPTION
After the move from master->main, the linter was not updated to reflect that.