### PR TITLE
add a fix to run linter on all PRs

### DIFF
--- a/.github/workflows/lint_code_base.yml
+++ b/.github/workflows/lint_code_base.yml
@@ -1,5 +1,11 @@
 name: Lint Code Base
-on: push
+on: 
+  push:
+    branches: 
+      - main
+  pull_request:
+    branches: 
+      - main
 jobs:
   linting:
     name: Lint


### PR DESCRIPTION
This is a small change based on the documentation that SHOULD run the linter before a PR can be merged.