### PR TITLE
remove references to staging branch

### DIFF
--- a/.github/workflows/lint_code_base.yml
+++ b/.github/workflows/lint_code_base.yml
@@ -3,11 +3,9 @@ on:
   push:
     branches: 
       - main
-      - staging
   pull_request:
     branches: 
       - main
-      - staging
 jobs:
   linting:
     name: Lint


### PR DESCRIPTION
The staging branch was a test to see if we could run environment based branches to have dev->staging->prod automated pipelines. To be honest, it just kinda confused things and the staging branch isn't used at all. I'm just yanking it out of everything. 

Instead we disabled the automated deployment process for prod and moved it to a manual one so that we can deploy a list of changes once/twice a day and have an actual "release" tagged in github.