### PR TITLE
Standardize git workflows

### DIFF
--- a/.github/workflows/lint_code_base.yml
+++ b/.github/workflows/lint_code_base.yml
@@ -14,11 +14,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Run Super-Linter
-        uses: github/super-linter@v3
-        env:
-          DEFAULT_BRANCH: main
-          LINTER_RULES_PATH: /
-          JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.js 
-          VALIDATE_JAVASCRIPT_ES: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Run linting
+        run: yarn lint

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,0 +1,16 @@
+name: Deploy Prod
+on:
+  release:
+    types: [published]
+
+
+jobs:
+  trigger_deploy:
+    name: Trigger DO Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Webhook
+        uses: joelwmale/webhook-action@master
+        with:
+          url: ${{ secrets.WEBHOOK_URL }}
+          headers: '{"Authorization": "Bearer ${{ secrets.DO_TOKEN }}"}'


### PR DESCRIPTION
1. Update the existing linter mechanism to utilize the packaged linter and linting commands instead of SuperLinter. This standardizes how our linter works so that it works the same locally as it does on github. 
2. Add the workflow for deploying to prod on a new release creation. This brings the deployment strategy in line with the other bao properties.